### PR TITLE
fix external-cert failing volume by using conditional

### DIFF
--- a/charts/all/llm/templates/llm-deployment.yaml
+++ b/charts/all/llm/templates/llm-deployment.yaml
@@ -72,12 +72,16 @@ spec:
           volumeMounts:
             - name: {{ .Values.global.amdllm.volume.tmp.name }}
               mountPath: {{ .Values.global.amdllm.volume.tmp.path }}
+            {{- if .Values.external_cert_enabled }}
             - name: {{ .Values.global.amdllm.volume.cert.name }}
               mountPath: {{ .Values.global.amdllm.volume.cert.path }}
+            {{- end }}
       restartPolicy: Always
       volumes:
         - name: {{ .Values.global.amdllm.volume.tmp.name }}
           emptyDir: {}
+        {{- if .Values.external_cert_enabled }}
         - name: {{ .Values.global.amdllm.volume.cert.name }}
           secret:
             secretName: {{ .Values.global.amdllm.volume.cert.name }}
+        {{- end }}

--- a/tests/all-llm-industrial-edge-factory.expected.yaml
+++ b/tests/all-llm-industrial-edge-factory.expected.yaml
@@ -80,15 +80,10 @@ spec:
           volumeMounts:
             - name: temp-data
               mountPath: /tmp/temp-data
-            - name: endpoint-cert
-              mountPath: /tmp
       restartPolicy: Always
       volumes:
         - name: temp-data
           emptyDir: {}
-        - name: endpoint-cert
-          secret:
-            secretName: endpoint-cert
 ---
 # Source: llm-server/templates/llm-buildconfig.yaml
 kind: BuildConfig

--- a/tests/all-llm-industrial-edge-hub.expected.yaml
+++ b/tests/all-llm-industrial-edge-hub.expected.yaml
@@ -80,15 +80,10 @@ spec:
           volumeMounts:
             - name: temp-data
               mountPath: /tmp/temp-data
-            - name: endpoint-cert
-              mountPath: /tmp
       restartPolicy: Always
       volumes:
         - name: temp-data
           emptyDir: {}
-        - name: endpoint-cert
-          secret:
-            secretName: endpoint-cert
 ---
 # Source: llm-server/templates/llm-buildconfig.yaml
 kind: BuildConfig

--- a/tests/all-llm-medical-diagnosis-hub.expected.yaml
+++ b/tests/all-llm-medical-diagnosis-hub.expected.yaml
@@ -80,15 +80,10 @@ spec:
           volumeMounts:
             - name: temp-data
               mountPath: /tmp/temp-data
-            - name: endpoint-cert
-              mountPath: /tmp
       restartPolicy: Always
       volumes:
         - name: temp-data
           emptyDir: {}
-        - name: endpoint-cert
-          secret:
-            secretName: endpoint-cert
 ---
 # Source: llm-server/templates/llm-buildconfig.yaml
 kind: BuildConfig

--- a/tests/all-llm-naked.expected.yaml
+++ b/tests/all-llm-naked.expected.yaml
@@ -80,15 +80,10 @@ spec:
           volumeMounts:
             - name: temp-data
               mountPath: /tmp/temp-data
-            - name: endpoint-cert
-              mountPath: /tmp
       restartPolicy: Always
       volumes:
         - name: temp-data
           emptyDir: {}
-        - name: endpoint-cert
-          secret:
-            secretName: endpoint-cert
 ---
 # Source: llm-server/templates/llm-buildconfig.yaml
 kind: BuildConfig

--- a/tests/all-llm-normal.expected.yaml
+++ b/tests/all-llm-normal.expected.yaml
@@ -80,15 +80,10 @@ spec:
           volumeMounts:
             - name: temp-data
               mountPath: /tmp/temp-data
-            - name: endpoint-cert
-              mountPath: /tmp
       restartPolicy: Always
       volumes:
         - name: temp-data
           emptyDir: {}
-        - name: endpoint-cert
-          secret:
-            secretName: endpoint-cert
 ---
 # Source: llm-server/templates/llm-buildconfig.yaml
 kind: BuildConfig


### PR DESCRIPTION
Tested in chart on cluster, fix will allow the secret init chain to work fine and the llm pod to deploy without the external secret by default without breaking.