### PR TITLE
fix ConsoleLink url in upper-right app menu to match secure route

### DIFF
--- a/charts/all/chatqna-ui/templates/ui-consolelink.yaml
+++ b/charts/all/chatqna-ui/templates/ui-consolelink.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "6"
 spec:
-  href: 'https://{{ .Values.global.amdllm.service_name }}-{{ .Values.global.amdllm.namespace }}.apps.{{ .Values.global.clusterDomain }}'
+  href: 'https://{{ .Values.global.amdllm.ui_service_name }}-{{ .Values.global.amdllm.namespace }}.apps.{{ .Values.global.clusterDomain }}'
   location: ApplicationMenu
   # This text will appear in a box called "Launcher" under "namespace" or "project" in the web console
   text: OPEA ChatQnA on AMD Instinct

--- a/charts/all/chatqna-ui/values.yaml
+++ b/charts/all/chatqna-ui/values.yaml
@@ -9,6 +9,7 @@ global:
     runtime_envs: []
 
     service_name: chatqna-ui
+    ui_service_name: chatqna-ui-secure
     service_port: 5009
     container_port: 5173
     source_context_dir: ChatQnA/ui

--- a/tests/all-chatqna-ui-industrial-edge-factory.expected.yaml
+++ b/tests/all-chatqna-ui-industrial-edge-factory.expected.yaml
@@ -125,7 +125,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "6"
 spec:
-  href: 'https://chatqna-ui-amd-llm.apps.region.example.com'
+  href: 'https://chatqna-ui-secure-amd-llm.apps.region.example.com'
   location: ApplicationMenu
   # This text will appear in a box called "Launcher" under "namespace" or "project" in the web console
   text: OPEA ChatQnA on AMD Instinct

--- a/tests/all-chatqna-ui-industrial-edge-hub.expected.yaml
+++ b/tests/all-chatqna-ui-industrial-edge-hub.expected.yaml
@@ -125,7 +125,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "6"
 spec:
-  href: 'https://chatqna-ui-amd-llm.apps.region.example.com'
+  href: 'https://chatqna-ui-secure-amd-llm.apps.region.example.com'
   location: ApplicationMenu
   # This text will appear in a box called "Launcher" under "namespace" or "project" in the web console
   text: OPEA ChatQnA on AMD Instinct

--- a/tests/all-chatqna-ui-medical-diagnosis-hub.expected.yaml
+++ b/tests/all-chatqna-ui-medical-diagnosis-hub.expected.yaml
@@ -125,7 +125,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "6"
 spec:
-  href: 'https://chatqna-ui-amd-llm.apps.region.example.com'
+  href: 'https://chatqna-ui-secure-amd-llm.apps.region.example.com'
   location: ApplicationMenu
   # This text will appear in a box called "Launcher" under "namespace" or "project" in the web console
   text: OPEA ChatQnA on AMD Instinct

--- a/tests/all-chatqna-ui-normal.expected.yaml
+++ b/tests/all-chatqna-ui-normal.expected.yaml
@@ -125,7 +125,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "6"
 spec:
-  href: 'https://chatqna-ui-amd-llm.apps.region.example.com'
+  href: 'https://chatqna-ui-secure-amd-llm.apps.region.example.com'
   location: ApplicationMenu
   # This text will appear in a box called "Launcher" under "namespace" or "project" in the web console
   text: OPEA ChatQnA on AMD Instinct


### PR DESCRIPTION
noticed that our app menu link is broken due to using `https://` with a route matching the insecure route available, updating menu link to use the secure route without messing with any other code using the global `service_name` it was referencing.